### PR TITLE
feat: add xerrors package which contains additions to the std errors

### DIFF
--- a/xerrors/xerrors.go
+++ b/xerrors/xerrors.go
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package xerrors contains the additions to std errors package.
+package xerrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// TypeIs is wrapper around errors.As which check the error type.
+func TypeIs[T error](err error) bool {
+	var expected T
+
+	return errors.As(err, &expected)
+}
+
+// TagIs is wrapper around errors.As which checks the error tag.
+func TagIs[T Tag](err error) bool {
+	var expected *Tagged[T]
+
+	return errors.As(err, &expected)
+}
+
+// Tag is a type which can be used to tag Tagged errors.
+type Tag interface {
+	~struct{}
+}
+
+// Tagged is an error with a tag attached. Tag can only be an empty struct.
+//
+//nolint:errname
+type Tagged[T Tag] struct {
+	err error
+}
+
+// NewTagged creates a new typed error.
+func NewTagged[T Tag](err error) error {
+	return &Tagged[T]{err: err}
+}
+
+// NewTaggedf creates a new typed error.
+func NewTaggedf[T Tag](format string, a ...any) error {
+	return &Tagged[T]{err: fmt.Errorf(format, a...)}
+}
+
+// Error implements error interface.
+func (e *Tagged[T]) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap implements errors.Unwrap.
+func (e *Tagged[T]) Unwrap() error {
+	return e.err
+}

--- a/xerrors/xerrors_test.go
+++ b/xerrors/xerrors_test.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package xerrors_test
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/gen/xerrors"
+)
+
+//nolint:unused
+type testTag struct{}
+
+func TestTagged(t *testing.T) {
+	stdErr := io.EOF
+	taggedErr := xerrors.NewTagged[testTag](stdErr)
+
+	require.True(t, xerrors.TypeIs[*xerrors.Tagged[testTag]](taggedErr))
+	require.True(t, xerrors.TagIs[testTag](taggedErr))
+	require.False(t, xerrors.TypeIs[*xerrors.Tagged[testTag]](stdErr))
+	require.False(t, xerrors.TagIs[testTag](stdErr))
+	require.ErrorIs(t, taggedErr, stdErr)
+
+	taggedfErr := xerrors.NewTaggedf[testTag]("my custom error around: %w", stdErr)
+
+	require.True(t, xerrors.TypeIs[*xerrors.Tagged[testTag]](taggedfErr))
+	require.True(t, xerrors.TagIs[testTag](taggedfErr))
+	require.ErrorIs(t, taggedfErr, stdErr)
+	require.EqualError(t, taggedErr, stdErr.Error())
+
+	taggedCustomErr := xerrors.NewTaggedf[testTag]("my custom error")
+
+	require.True(t, xerrors.TypeIs[*xerrors.Tagged[testTag]](taggedCustomErr))
+	require.True(t, xerrors.TagIs[testTag](taggedCustomErr))
+	require.False(t, errors.Is(taggedCustomErr, stdErr))
+}


### PR DESCRIPTION
The additions are:
- TypeIs which is basically a wrapper around errors.As
- Tagged error type which allows to add type tags to the error chain.
- TagIs which is similar to TypeIs but shorter.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>