### PR TITLE
chore: set `slice.Filter` result slice cap to len

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -62,7 +62,7 @@ func Filter[S ~[]T, T any](slc S, fn func(T) bool) S {
 		return nil
 	}
 
-	return r
+	return r[:len(r):len(r)]
 }
 
 // FilterInPlace filters the slice in place.


### PR DESCRIPTION
This change ensures that if we `append` to resulting slice in different places, we will not use the same underlying memory.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>