### PR TITLE
chore: add more utilities to xiter

### DIFF
--- a/xiter/xiter.go
+++ b/xiter/xiter.go
@@ -70,7 +70,7 @@ func Equal2[K, V comparable](x, y iter.Seq2[K, V]) bool {
 }
 
 // EqualFunc reports whether the two sequences are equal according to the function f.
-func EqualFunc[V1, V2 any](x iter.Seq[V1], y iter.Seq[V2], f func(V1, V2) bool) bool {
+func EqualFunc[V1, V2 any](f func(V1, V2) bool, x iter.Seq[V1], y iter.Seq[V2]) bool {
 	next, stop := iter.Pull(y)
 	defer stop()
 
@@ -87,7 +87,7 @@ func EqualFunc[V1, V2 any](x iter.Seq[V1], y iter.Seq[V2], f func(V1, V2) bool) 
 }
 
 // EqualFunc2 reports whether the two sequences are equal according to the function f.
-func EqualFunc2[K1, V1, K2, V2 any](x iter.Seq2[K1, V1], y iter.Seq2[K2, V2], f func(K1, V1, K2, V2) bool) bool {
+func EqualFunc2[K1, V1, K2, V2 any](f func(K1, V1, K2, V2) bool, x iter.Seq2[K1, V1], y iter.Seq2[K2, V2]) bool {
 	next, stop := iter.Pull2(y)
 	defer stop()
 
@@ -104,7 +104,7 @@ func EqualFunc2[K1, V1, K2, V2 any](x iter.Seq2[K1, V1], y iter.Seq2[K2, V2], f 
 }
 
 // Map returns an iterator over f applied to seq.
-func Map[In, Out any](seq iter.Seq[In], f func(In) Out) iter.Seq[Out] {
+func Map[In, Out any](f func(In) Out, seq iter.Seq[In]) iter.Seq[Out] {
 	return func(yield func(Out) bool) {
 		for in := range seq {
 			if !yield(f(in)) {
@@ -115,7 +115,7 @@ func Map[In, Out any](seq iter.Seq[In], f func(In) Out) iter.Seq[Out] {
 }
 
 // Map2 returns an iterator over f applied to seq.
-func Map2[KIn, VIn, KOut, VOut any](seq iter.Seq2[KIn, VIn], f func(KIn, VIn) (KOut, VOut)) iter.Seq2[KOut, VOut] {
+func Map2[KIn, VIn, KOut, VOut any](f func(KIn, VIn) (KOut, VOut), seq iter.Seq2[KIn, VIn]) iter.Seq2[KOut, VOut] {
 	return func(yield func(KOut, VOut) bool) {
 		for k, v := range seq {
 			if !yield(f(k, v)) {
@@ -126,7 +126,7 @@ func Map2[KIn, VIn, KOut, VOut any](seq iter.Seq2[KIn, VIn], f func(KIn, VIn) (K
 }
 
 // Filter returns an iterator over the elements in seq for which f returns true.
-func Filter[V any](seq iter.Seq[V], f func(V) bool) iter.Seq[V] {
+func Filter[V any](f func(V) bool, seq iter.Seq[V]) iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for e := range seq {
 			if !f(e) {
@@ -141,7 +141,7 @@ func Filter[V any](seq iter.Seq[V], f func(V) bool) iter.Seq[V] {
 }
 
 // Filter2 returns an iterator over the elements in seq for which f returns true.
-func Filter2[K, V any](seq iter.Seq2[K, V], f func(K, V) bool) iter.Seq2[K, V] {
+func Filter2[K, V any](f func(K, V) bool, seq iter.Seq2[K, V]) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for k, v := range seq {
 			if !f(k, v) {
@@ -155,8 +155,8 @@ func Filter2[K, V any](seq iter.Seq2[K, V], f func(K, V) bool) iter.Seq2[K, V] {
 	}
 }
 
-// IterKeys returns an iterator over the keys in seq.
-func IterKeys[K, V any](seq iter.Seq2[K, V]) iter.Seq[K] {
+// Keys returns an iterator over the keys in seq.
+func Keys[K, V any](seq iter.Seq2[K, V]) iter.Seq[K] {
 	return func(yield func(K) bool) {
 		for k := range seq {
 			if !yield(k) {
@@ -178,7 +178,7 @@ func Values[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
 }
 
 // ToSeq returns an iterator where each element is the result of applying fn to the elements in seq.
-func ToSeq[K, V, R any](seq iter.Seq2[K, V], fn func(K, V) R) iter.Seq[R] {
+func ToSeq[K, V, R any](fn func(K, V) R, seq iter.Seq2[K, V]) iter.Seq[R] {
 	return func(yield func(R) bool) {
 		for k, v := range seq {
 			if !yield(fn(k, v)) {
@@ -189,7 +189,7 @@ func ToSeq[K, V, R any](seq iter.Seq2[K, V], fn func(K, V) R) iter.Seq[R] {
 }
 
 // ToSeq2 returns an iterator where each element is the result of applying fn to the elements in seq.
-func ToSeq2[V1, R1, R2 any](seq iter.Seq[V1], fn func(V1) (R1, R2)) iter.Seq2[R1, R2] {
+func ToSeq2[V1, R1, R2 any](fn func(V1) (R1, R2), seq iter.Seq[V1]) iter.Seq2[R1, R2] {
 	return func(yield func(R1, R2) bool) {
 		for v := range seq {
 			if !yield(fn(v)) {
@@ -199,26 +199,22 @@ func ToSeq2[V1, R1, R2 any](seq iter.Seq[V1], fn func(V1) (R1, R2)) iter.Seq2[R1
 	}
 }
 
-// Fold applies f to the elements in seq, starting with the initial value.
-func Fold[V, R any](seq iter.Seq[V], initial R, f func(R, V) R) R {
-	result := initial
-
+// Reduce applies f to the elements in seq, starting with the initial value.
+func Reduce[V, R any](f func(R, V) R, sum R, seq iter.Seq[V]) R {
 	for e := range seq {
-		result = f(result, e)
+		sum = f(sum, e)
 	}
 
-	return result
+	return sum
 }
 
-// Fold2 applies f to the elements in seq, starting with the initial value.
-func Fold2[K, V, R any](seq iter.Seq2[K, V], initial R, f func(R, K, V) R) R {
-	result := initial
-
+// Reduce2 applies f to the elements in seq, starting with the initial value.
+func Reduce2[K, V, R any](f func(R, K, V) R, sum R, seq iter.Seq2[K, V]) R {
 	for k, v := range seq {
-		result = f(result, k, v)
+		sum = f(sum, k, v)
 	}
 
-	return result
+	return sum
 }
 
 // Empty returns an empty iterator.
@@ -226,3 +222,31 @@ func Empty[V any](func(V) bool) {}
 
 // Empty2 returns an empty iterator.
 func Empty2[V, V2 any](func(V, V2) bool) {}
+
+// Single returns an iterator over a single element.
+func Single[V any](v V) iter.Seq[V] { return func(yield func(V) bool) { yield(v) } }
+
+// Single2 returns an iterator over a single element.
+func Single2[K, V any](k K, v V) iter.Seq2[K, V] { return func(yield func(K, V) bool) { yield(k, v) } }
+
+// Find returns the first element in seq for which f returns true.
+func Find[V any](f func(V) bool, seq iter.Seq[V]) (V, bool) {
+	for e := range seq {
+		if f(e) {
+			return e, true
+		}
+	}
+
+	return *new(V), false
+}
+
+// Find2 returns the first element in seq for which f returns true.
+func Find2[K, V any](f func(K, V) bool, seq iter.Seq2[K, V]) (K, V, bool) {
+	for k, v := range seq {
+		if f(k, v) {
+			return k, v, true
+		}
+	}
+
+	return *new(K), *new(V), false
+}


### PR DESCRIPTION
This is breaking change PR:
- Reorder `func` in xiter package, so that it's always first. That helps with several transformations in one place. See [this](https://github.com/golang/go/issues/61898#issuecomment-2112841326).
- Add `Single` and `Single2` iterators.
- Add `Find` and `Find2` iterators.
- Rename `Fold` to `Reduce`.
- Other small changes.