### PR TITLE
feat: add `panicsafe` package

### DIFF
--- a/panicsafe/panicsafe.go
+++ b/panicsafe/panicsafe.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package panicsafe provides panic-handling function wrappers, helpful when spawning goroutines which should never panic.
+package panicsafe
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+)
+
+var errPanic = errors.New("goroutine panicked")
+
+// IsPanic checks if the given error is a panic error.
+func IsPanic(err error) bool {
+	return errors.Is(err, errPanic)
+}
+
+// Run runs the given function, handling panics and converting them to errors.
+func Run(f func()) error {
+	return RunErrF(func() error {
+		f()
+
+		return nil
+	})()
+}
+
+// RunErr runs the given error-returning function, handling panics and converting them to errors.
+func RunErr(f func() error) error {
+	return RunErrF(f)()
+}
+
+// RunErrF returns a function which wraps the given error-returning function, handling panics and converting them to errors.
+func RunErrF(f func() error) func() error {
+	return func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+
+				if rError, ok := r.(error); ok { // if the panic is an error, we wrap it as well
+					err = fmt.Errorf("%w: %w\n%s", errPanic, rError, string(stack))
+
+					return
+				}
+
+				err = fmt.Errorf("%w: %s\n%s", errPanic, r, string(stack))
+			}
+		}()
+
+		return f()
+	}
+}

--- a/panicsafe/panicsafe_test.go
+++ b/panicsafe/panicsafe_test.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package panicsafe_test
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/gen/panicsafe"
+)
+
+func TestRunNoPanic(t *testing.T) {
+	ran := false
+
+	err := panicsafe.Run(func() { ran = true })
+	require.NoError(t, err)
+
+	require.True(t, ran, "function should have run without panic")
+}
+
+func TestRunPanic(t *testing.T) {
+	err := panicsafe.Run(func() {
+		panic("test panic")
+	})
+	assert.True(t, panicsafe.IsPanic(err))
+
+	assert.ErrorContains(t, err, "test panic")
+	assertStackTrace(t, err)
+}
+
+func TestRunErr(t *testing.T) {
+	testErr := errors.New("test err")
+
+	err := panicsafe.RunErr(func() error {
+		return testErr
+	})
+	assert.False(t, panicsafe.IsPanic(err))
+
+	assert.Equal(t, testErr, err)
+}
+
+func TestRunErrPanic(t *testing.T) {
+	err := panicsafe.RunErr(func() error {
+		panic("test panic")
+	})
+	assert.True(t, panicsafe.IsPanic(err))
+
+	assertStackTrace(t, err)
+}
+
+func TestPanicErrType(t *testing.T) {
+	testErr := errors.New("test err")
+
+	err := panicsafe.Run(func() {
+		panic(testErr)
+	})
+
+	assert.True(t, panicsafe.IsPanic(err))
+	assert.ErrorIs(t, err, testErr, "both panicsafe.ErrPanic and the original error should be wrapped")
+
+	assertStackTrace(t, err)
+}
+
+func assertStackTrace(t *testing.T, err error) {
+	file, callerFunc := trace(1) // skip this very function
+
+	assert.ErrorContains(t, err, "runtime/debug.Stack()")
+	assert.ErrorContains(t, err, callerFunc)
+	assert.ErrorContains(t, err, file)
+}
+
+// trace returns the file and function name of the caller.
+func trace(skip int) (file, function string) {
+	pc := make([]uintptr, 15)
+	n := runtime.Callers(2+skip, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+
+	return frame.File, frame.Function
+}

--- a/xyaml/xyaml_test.go
+++ b/xyaml/xyaml_test.go
@@ -8,8 +8,9 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/siderolabs/gen/xyaml"
 	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/gen/xyaml"
 )
 
 type A struct {


### PR DESCRIPTION
Add the panicsafe package to wrap goroutines which should never panic. The helper functions convert the panics into errors.