### PR TITLE
fix: skip unknown-key check for types with custom YAML unmarshaler

### DIFF
--- a/xyaml/xyaml.go
+++ b/xyaml/xyaml.go
@@ -107,7 +107,25 @@ func structKeys(typ reflect.Type) (map[string][]int, reflect.Type) {
 	return availableKeys, typ
 }
 
-var typeOfInterfaceAny = reflect.TypeOf((*any)(nil)).Elem()
+// obsoleteUnmarshaler is the deprecated unmarshaler interface still supported by the YAML library.
+type obsoleteUnmarshaler interface {
+	UnmarshalYAML(unmarshal func(any) error) error
+}
+
+var (
+	typeOfInterfaceAny = reflect.TypeOf((*any)(nil)).Elem()
+
+	typeOfUnmarshaler         = reflect.TypeOf((*yaml.Unmarshaler)(nil)).Elem()
+	typeOfObsoleteUnmarshaler = reflect.TypeOf((*obsoleteUnmarshaler)(nil)).Elem()
+)
+
+// implementsUnmarshaler checks if the type (or a pointer to it) has a custom YAML unmarshaler.
+func implementsUnmarshaler(typ reflect.Type) bool {
+	ptr := reflect.PointerTo(typ)
+
+	return typ.Implements(typeOfUnmarshaler) || ptr.Implements(typeOfUnmarshaler) ||
+		typ.Implements(typeOfObsoleteUnmarshaler) || ptr.Implements(typeOfObsoleteUnmarshaler)
+}
 
 //nolint:gocyclo,cyclop,gocognit
 func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown any, err error) {
@@ -130,6 +148,11 @@ func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown any, e
 		case reflect.Struct:
 			availableKeys, typ = structKeys(typ)
 		default:
+			// a custom unmarshaler may accept a mapping into a non-struct type
+			if implementsUnmarshaler(typ) {
+				return nil, nil //nolint:nilnil
+			}
+
 			return unknown, fmt.Errorf("unexpected type for yaml mapping: %s", typ)
 		}
 
@@ -178,6 +201,11 @@ func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown any, e
 		}
 	case yaml.SequenceNode:
 		if typ.Kind() != reflect.Slice {
+			// a custom unmarshaler may accept a sequence into a non-slice type
+			if implementsUnmarshaler(typ) {
+				return nil, nil //nolint:nilnil
+			}
+
 			return unknown, fmt.Errorf("unexpected type for yaml sequence: %s", typ)
 		}
 

--- a/xyaml/xyaml_test.go
+++ b/xyaml/xyaml_test.go
@@ -19,6 +19,27 @@ type A struct {
 	Slice []A               `yaml:"slice"`
 }
 
+// argValue is a custom unmarshaler accepting either a scalar or a sequence.
+type argValue struct {
+	str  string
+	list []string
+}
+
+func (a *argValue) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err == nil {
+		a.str = s
+
+		return nil
+	}
+
+	return unmarshal(&a.list)
+}
+
+type withArgs struct {
+	Args map[string]argValue `yaml:"args"`
+}
+
 //go:embed testdata/valid.yaml
 var valid []byte
 
@@ -69,6 +90,29 @@ func TestUnmarshalStrict(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+		})
+	}
+}
+
+// TestUnmarshalStrictCustomUnmarshaler checks that a node shape accepted by a custom unmarshaler is not rejected.
+func TestUnmarshalStrictCustomUnmarshaler(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		data string
+	}{
+		{
+			name: "scalar arg value",
+			data: "args:\n  issuer: https://one\n",
+		},
+		{
+			name: "sequence arg value",
+			data: "args:\n  issuer:\n    - https://one\n    - https://two\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var w withArgs
+
+			require.NoError(t, xyaml.UnmarshalStrict([]byte(tt.data), &w))
 		})
 	}
 }


### PR DESCRIPTION
CheckUnknownKeys walks the Go type structure against the YAML node and errors when the kinds disagree (e.g. a sequence node decoded into a struct). Types with a custom UnmarshalYAML control their own decoding and may legitimately accept a node shape that does not match their Go type, so the structural check is invalid for them.

This surfaced in Talos: kube-apiserver `extraArgs` values use a custom ArgValue type accepting either a scalar or a sequence. A list-form value such as multiple `service-account-issuer` entries decoded fine but was then rejected by CheckUnknownKeys with:

    unexpected type for yaml sequence: v1alpha1.ArgValue

Skip the check only where the node kind cannot match the Go type and that type implements the current or obsolete yaml unmarshaler interface. This fixes the false rejection while leaving all other key checking (including nested slices and maps) unchanged.